### PR TITLE
Path params temp

### DIFF
--- a/openplugin/core/operations/implementations/operation_signature_builder_with_openai.py
+++ b/openplugin/core/operations/implementations/operation_signature_builder_with_openai.py
@@ -1,6 +1,7 @@
 import json
 import time
 from typing import List, Optional
+import re
 import litellm
 
 from openplugin.core import (
@@ -176,7 +177,11 @@ class OpenAIOperationSignatureBuilder(OperationSignatureBuilder):
             and isinstance(message_json, dict)
             and message_json.get("function_call")
         ):
-            function_name = message_json["function_call"]["name"]
+            # validate for litellm character restrictions: r"^[a-zA-Z0-9_-]{1,64}$"
+            pattern = re.compile("[a-zA-Z0-9_-]{1,64}")
+            matches = pattern.findall(message_json["function_call"]["name"])
+            validated_name = ''.join(matches)
+            function_name = validated_name
             detected_plugin = functions.get_plugin_from_func_name(function_name)
             detected_function = functions.get_function_from_func_name(function_name)
             arguments = json.loads(message_json["function_call"]["arguments"])

--- a/openplugin/core/plugin_execution_pipeline.py
+++ b/openplugin/core/plugin_execution_pipeline.py
@@ -283,11 +283,9 @@ class PluginExecutionPipeline(BaseModel):
             raise Exception("Input data type to plugin must be JSON.")
         if input.value is None:
             raise PortValueError("Input value cannot be None")
-
-        # remove path params from api url
-        api_called = re.sub(r'/\{[^}]*\}$', '', input.value.get("api_called"))
-        method = input.value.get("method")
+        
         api_called = input.value.get("api_called") 
+        method = input.value.get("method")
         query_params = input.value.get("mapped_operation_parameters")
 
         # identify path parameters

--- a/openplugin/core/selectors/implementations/plugin_selector_with_openai.py
+++ b/openplugin/core/selectors/implementations/plugin_selector_with_openai.py
@@ -13,7 +13,7 @@ from openplugin.core import (
 )
 
 from ..plugin_selector import PluginSelector
-
+import re
 
 class OpenAIPluginSelector(PluginSelector):
     def __init__(
@@ -86,7 +86,11 @@ class OpenAIPluginSelector(PluginSelector):
         message = response["choices"][0]["message"]
         detected_plugins = []
         if message.get("function_call"):
-            function_name = message.get("function_call").name
+            # validate for litellm character restrictions: r"^[a-zA-Z0-9_-]{1,64}$"
+            pattern = re.compile("[a-zA-Z0-9_-]{1,64}")
+            matches = pattern.findall(message.get("function_call").name)
+            validated_name = ''.join(matches)
+            function_name = validated_name
             detected_plugin = functions.get_plugin_from_func_name(function_name)
             detected_function = functions.get_function_from_func_name(function_name)
             p_detected = PluginDetected(


### PR DESCRIPTION
Added validation to remove path parameter brackets from "function_name" value where they cause the error 'get_posts_{postId}' does not match '^[a-zA-Z0-9_-]{1,64}$'

Replaced path parameter with its actual value in endpoint URL before request is sent to API in core/openplugin_execution_piprline.py